### PR TITLE
Add "%F" replacement

### DIFF
--- a/lib/moment-strftime.coffee
+++ b/lib/moment-strftime.coffee
@@ -9,6 +9,7 @@ replacements =
   b: 'MMM'
   B: 'MMMM'
   d: 'DD'
+  F: 'YYYY-MM-DD'
   H: 'HH'
   I: 'hh'
   j: 'DDDD'


### PR DESCRIPTION
"%F" is a common shortcut for the `date` command in Unix and would be nice to have in JavaScript.
