### PR TITLE
cake build does not work on windows

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -11,12 +11,12 @@ task 'clean', 'Clean generated files', ->
   rmrf.sync('node_modules')
 
 task 'spec', 'Run Jasmine specs in spec/', ->
-  exec 'node_modules/.bin/jasmine-node --coffee spec/', callback
+  exec 'jasmine-node --coffee spec/', callback
 
 task 'build', 'Build to minified JavaScript', ->
-  exec 'node_modules/.bin/coffee --output build --compile --join moment-strftime.js lib/*.coffee', (err, stdout, stderr) ->
+  exec 'coffee --output build --compile lib/moment-strftime.coffee', (err, stdout, stderr) ->
     callback(err, stdout, stderr)
-    exec 'node_modules/.bin/uglifyjs --output build/moment-strftime.min.js build/moment-strftime.js', callback
+    exec 'uglifyjs --output build/moment-strftime.min.js build/moment-strftime.js', callback
 
 task 'release', 'Generate release files', ->
   packageInfo = JSON.parse(fs.readFileSync('package.json'))


### PR DESCRIPTION
The current Cakefile throws errors on Windows:
```
C:\Program Files\EasyPHP-DevServer-14.1VC11\data\localweb\moment-strftime\Cakefile:12
      throw err;
            ^
Error: Command failed: C:\Windows\system32\cmd.exe /s /c "node_modules/.bin/coffee --output build --compile --join moment-strftime.js lib/*.coffee"
'node_modules' n'est pas reconnu en tant que commande interne
ou externe, un programme ex�cutable ou un fichier de commandes.

  at ChildProcess.exithandler (child_process.js:744:12)
  at ChildProcess.emit (events.js:110:17)
  at maybeClose (child_process.js:1008:16)
  at Socket.<anonymous> (child_process.js:1176:11)
  at Socket.emit (events.js:107:17)
  at Pipe.close (net.js:476:12)
```

Here is a patch to make it work on Windows.