### PR TITLE
Update moment dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 .roboconf.sh
 !/build/moment-strftime.min.js
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
         "spec"
     ],
     "dependencies": {
-        "moment": "~1.3.0"
+        "moment": "~2.10.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 
   "dependencies": {
     "coffee-script": "1.2.0",
-    "moment": "1.3.0"
+    "moment": "~2.10.3"
   },
 
   "devDependencies": {


### PR DESCRIPTION
Hello,

I think we can safely update the dependency to 2.10.3. I've been using it like this for a few days and didn't notice any bug.

Regards,