### PR TITLE
Adding day of the month without leading zero (%e)

### DIFF
--- a/lib/moment-strftime.coffee
+++ b/lib/moment-strftime.coffee
@@ -9,6 +9,7 @@ replacements =
   b: 'MMM'
   B: 'MMMM'
   d: 'DD'
+  e: 'D'
   F: 'YYYY-MM-DD'
   H: 'HH'
   I: 'hh'


### PR DESCRIPTION
Strftime accepts a %e format value, which is the day of the month without leading zero.