### PR TITLE
Update version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "moment-strftime",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "homepage": "https://github.com/benjaminoakes/moment-strftime",
     "authors": [
         "Benjamin Oakes <hello@benjaminoakes.com> (http://www.benjaminoakes.com/)"


### PR DESCRIPTION
It causes a Bower warning:
"Version declared in the json (0.1.2) is different than the resolved one (0.1.3)"