### PR TITLE
Don't format normal non-parametrized text

### DIFF
--- a/lib/moment-strftime.js
+++ b/lib/moment-strftime.js
@@ -37,7 +37,8 @@
   moment.fn.strftime = function (format) {
     var momentFormat, value;
 
-    momentFormat = format;
+    // Convert sequences of letters to bracket-enclosed moment format literals
+    momentFormat = format.replace(/[^%](\w+)/g, function(x) { return '[' + x + ']';});
 
     Object.keys(replacements).forEach(function (key) {
       value = replacements[key];

--- a/spec/strftime.spec.js
+++ b/spec/strftime.spec.js
@@ -159,6 +159,12 @@ describe('strftime', function () {
     });
   });
 
+  describe('given any non-parametrized text', function () {
+    it('gives the same text', function () {
+      expect(january17.strftime('hello world')).toEqual('hello world');
+    });
+  });
+
   it('formats correctly with a compound format', function () {
     expect(january17.strftime("%m/%d/%y %I:%M %p")).toEqual('01/17/12 07:54 PM');
   });


### PR DESCRIPTION
Currently `moment-strftime` formats non-parametrized text, which shouldn't be formatted. This pull request fixes this issue.