### PR TITLE
Update moment dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,10 +17,9 @@
         "**/.*",
         "node_modules",
         "bower_components",
-        "lib",
         "spec"
     ],
     "dependencies": {
-        "moment": "~2.10.3"
+        "moment": "~2.10"
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
 
   "dependencies": {
-    "moment": "~2.10.3"
+    "moment": "~2.10"
   },
 
   "devDependencies": {


### PR DESCRIPTION
Depending on ~2.10.3 only works with moment 2.10.\*,
the current version is 2.12 .. AFAICT it seems moment is semver enough for us to just say 2.\* is OK.

@benjaminoakes do you agree? Would you mind doing a new release please, if so?