### PR TITLE
Fix webpack critical dependency warning

### DIFF
--- a/lib/moment-strftime.js
+++ b/lib/moment-strftime.js
@@ -1,7 +1,7 @@
 (function () {
   var moment, replacements;
 
-  if (typeof require !== "undefined" && require !== null) {
+  if (typeof require === "function") {
     moment = require('moment');
   } else {
     moment = this.moment;


### PR DESCRIPTION
The `require !== null` seems to annoy webpack. This also fixes an edge case where require could be `!= null`, but not a function.

Closes #20.

Thanks to webpack/webpack#2941.