### PR TITLE
Relax moment dependency constraint

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
         "spec"
     ],
     "dependencies": {
-        "moment": "~2.10"
+        "moment": "^2.10"
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
 
   "dependencies": {
-    "moment": "~2.10"
+    "moment": "^2.10"
   },
 
   "devDependencies": {


### PR DESCRIPTION
Hi,

`~2.10` matches all `2.10.x` versions but doesn't match `2.11` and newer versions. This means that in our project (which currently uses moment 2.17.1) we have to pull in a second moment version just for moment-strftime.

I think it's safe to assume that moment follows semver and as such, new minor releases in the `2.x` series won't break backward compatibility. Therefore `^2.10` is the correct version specifier, since it includes all releases in the `2.x.x` major release, starting with `2.10.0`. This will let us use moment-strftime with moment 2.17.
