### PR TITLE
More accurate replacement of strftime tokens

### DIFF
--- a/lib/moment-strftime.js
+++ b/lib/moment-strftime.js
@@ -39,15 +39,18 @@
   };
 
   moment.fn.strftime = function (format) {
-    var momentFormat, value;
+    var momentFormat, tokens;
 
-    // Convert sequences of letters to bracket-enclosed moment format literals
-    momentFormat = format.replace(/[^%](\w+)/g, function (literal) { return '[' + literal + ']'; });
-
-    Object.keys(replacements).forEach(function (key) {
-      value = replacements[key];
-      momentFormat = momentFormat.replace("%" + key, value);
-    });
+    // Break up format string based on strftime tokens
+    tokens = format.split(/(%.)/);
+    momentFormat = tokens.map(function (token) {
+      // Replace strftime tokens with moment formats
+      if (token[0] === '%' && replacements.hasOwnProperty(token[1])) {
+        return replacements[token[1]];
+      }
+      // Escape non-token strings to avoid accidental formatting
+      return token.length > 0 ? '[' + token + ']' : token;
+    }).join('');
 
     return this.format(momentFormat);
   };

--- a/spec/strftime.spec.js
+++ b/spec/strftime.spec.js
@@ -185,6 +185,12 @@ describe('strftime', function () {
     });
   });
 
+  describe('given an unknown token', function() {
+    it('gives the same token unreplaced', function() {
+      expect(january17.strftime('%Q')).toEqual('%Q');
+    });
+  });
+
   describe('given %d of month %m', function () {
     it('gives "%d of month %m"', function () {
       expect(january17.strftime('%d of month %m')).toEqual('17 of month 01');
@@ -197,7 +203,17 @@ describe('strftime', function () {
     });
   });
 
-  it('formats correctly with a compound format', function () {
-    expect(january17.strftime("%m/%d/%y %I:%M %p")).toEqual('01/17/12 07:54 PM');
+  describe('given a compound format', function() {
+    it('formats correctly with distinct tokens', function () {
+      expect(january17.strftime('%m/%d/%y %I:%M %p')).toEqual('01/17/12 07:54 PM');
+    });
+
+    it('formats correctly with tokens surrounding other letters', function() {
+      expect(january17.strftime('%Y-%m-%dT%H:%M')).toEqual('2012-01-17T19:54');
+    });
+
+    it('formats correctly with tokens within words', function() {
+      expect(january17.strftime('a code is month%m%Yyear')).toEqual('a code is month012012year');
+    });
   });
 });


### PR DESCRIPTION
I found a bug when trying to output an ISO 8601 timestamp. A strftime token followed immediately by another letter was counted as non-token text and was escaped to avoid formatting.

```js
moment.utc().strftime('%Y-%m-%dT%H:%M:%SZ');
// "2018-04-%dT04:31:%SZ"
```

From looking at the code, I also saw that it would fail to replace the same token twice in a string:

```js
moment().strftime('day %d = %d');
// "day 27 = %5"
```

This PR changes the replacement/escaping method by splitting the string into an array of exact tokens and other non-token strings. It then replaces the known tokens and escapes everything else.

This also incidentally fixes #25 (which is covered by the last test case).