### PR TITLE
Support for unpadded tokens

### DIFF
--- a/lib/moment-strftime.js
+++ b/lib/moment-strftime.js
@@ -14,17 +14,24 @@
     B: 'MMMM',
     c: 'lll',
     d: 'DD',
+    '-d': 'D',
     e: 'D',
     F: 'YYYY-MM-DD',
     H: 'HH',
+    '-H': 'H',
     I: 'hh',
+    '-I': 'h',
     j: 'DDDD',
+    '-j': 'DDD',
     k: 'H',
     l: 'h',
     m: 'MM',
+    '-m': 'M',
     M: 'mm',
+    '-M': 'm',
     p: 'A',
     S: 'ss',
+    '-S': 's',
     u: 'E',
     w: 'd',
     W: 'WW',
@@ -42,11 +49,11 @@
     var momentFormat, tokens;
 
     // Break up format string based on strftime tokens
-    tokens = format.split(/(%.)/);
+    tokens = format.split(/(%\-?.)/);
     momentFormat = tokens.map(function (token) {
       // Replace strftime tokens with moment formats
-      if (token[0] === '%' && replacements.hasOwnProperty(token[1])) {
-        return replacements[token[1]];
+      if (token[0] === '%' && replacements.hasOwnProperty(token.substr(1))) {
+        return replacements[token.substr(1)];
       }
       // Escape non-token strings to avoid accidental formatting
       return token.length > 0 ? '[' + token + ']' : token;

--- a/spec/strftime.spec.js
+++ b/spec/strftime.spec.js
@@ -47,6 +47,13 @@ describe('strftime', function () {
     });
   });
 
+  describe('given %-d', function () {
+    it('gives day of the month (1..31)', function () {
+      expect(january17.strftime('%-d')).toEqual('17');
+      expect(december2.strftime('%-d')).toEqual('2');
+    });
+  });
+
   describe('given %e', function () {
     it('gives day of the month (1..31)', function () {
       expect(january17.strftime('%e')).toEqual('17');
@@ -61,6 +68,13 @@ describe('strftime', function () {
     });
   });
 
+  describe('given %-H', function () {
+    it('gives hour of the day, 24-hour clock (00..23)', function () {
+      expect(january17.strftime('%-H')).toEqual('19');
+      expect(december2.strftime('%-H')).toEqual('1');
+    });
+  });
+
   describe('given %I', function () {
     it('gives hour of the day, 12-hour clock (01..12)', function () {
       expect(january17.strftime('%I')).toEqual('07');
@@ -68,9 +82,22 @@ describe('strftime', function () {
     });
   });
 
+  describe('given %-I', function () {
+    it('gives hour of the day, 12-hour clock (01..12)', function () {
+      expect(january17.strftime('%-I')).toEqual('7');
+      expect(december2.strftime('%-I')).toEqual('1');
+    });
+  });
+
   describe('given %j', function () {
     it('gives day of the year (001..366)', function () {
       expect(january17.strftime('%j')).toEqual('017');
+    });
+  });
+
+  describe('given %-j', function () {
+    it('gives day of the year (001..366)', function () {
+      expect(january17.strftime('%-j')).toEqual('17');
     });
   });
 
@@ -94,9 +121,21 @@ describe('strftime', function () {
     });
   });
 
+  describe('given %-m', function () {
+    it('gives month of the year (01..12)', function () {
+      expect(january17.strftime('%-m')).toEqual('1');
+    });
+  });
+
   describe('given %M', function () {
     it('gives minute of the hour (00..59)', function () {
-      expect(january17.strftime('%M')).toEqual('54');
+      expect(december2.strftime('%M')).toEqual('02');
+    });
+  });
+
+  describe('given %-M', function () {
+    it('gives minute of the hour (00..59)', function () {
+      expect(december2.strftime('%-M')).toEqual('2');
     });
   });
 
@@ -108,7 +147,13 @@ describe('strftime', function () {
 
   describe('given %S', function () {
     it('gives second of the minute (00..60)', function () {
-      expect(january17.strftime('%S')).toEqual('20');
+      expect(december2.strftime('%S')).toEqual('03');
+    });
+  });
+
+  describe('given %-S', function () {
+    it('gives second of the minute (00..60)', function () {
+      expect(december2.strftime('%-S')).toEqual('3');
     });
   });
 


### PR DESCRIPTION
Hello, thanks for the great plugin.

Here I'm adding support for "unpadded" tokens like `%-d`

Tokens added: 
- %-d
- %-H
- %-I
- %-j
- %-m
- %-M
- %-S

Doc used: http://strftime.org/